### PR TITLE
feat: Oauth2 인증 서비스 추가 [ISSUE-#3]

### DIFF
--- a/application/api/src/main/java/com/vrr/libs/auth/info/OAuth2UserInfoFactory.java
+++ b/application/api/src/main/java/com/vrr/libs/auth/info/OAuth2UserInfoFactory.java
@@ -2,6 +2,8 @@ package com.vrr.libs.auth.info;
 
 import com.vrr.code.auth.ProviderType;
 import com.vrr.libs.auth.info.implement.GoogleOAuth2UserInfo;
+import com.vrr.libs.auth.info.implement.KakaoOAuth2UserInfo;
+import com.vrr.libs.auth.info.implement.NaverOAuth2UserInfo;
 
 import java.util.Map;
 
@@ -10,6 +12,8 @@ public class OAuth2UserInfoFactory {
     public static OAuth2UserInfo getOAuth2UserInfo(ProviderType providerType, Map<String, Object> attributes) {
         switch (providerType) {
             case GOOGLE: return new GoogleOAuth2UserInfo(attributes);
+            case KAKAO: return new KakaoOAuth2UserInfo(attributes);
+            case NAVER: return new NaverOAuth2UserInfo(attributes);
             default: throw new IllegalArgumentException("Invalid Provider Type.");
         }
     }

--- a/application/api/src/main/java/com/vrr/libs/auth/info/implement/KakaoOAuth2UserInfo.java
+++ b/application/api/src/main/java/com/vrr/libs/auth/info/implement/KakaoOAuth2UserInfo.java
@@ -28,7 +28,13 @@ public class KakaoOAuth2UserInfo extends OAuth2UserInfo {
 
     @Override
     public String getEmail() {
-        return (String) attributes.get("account_email");
+        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+
+        if (account == null) {
+            return null;
+        }
+
+        return (String) account.get("email");
     }
 
     @Override

--- a/application/api/src/main/java/com/vrr/libs/auth/info/implement/KakaoOAuth2UserInfo.java
+++ b/application/api/src/main/java/com/vrr/libs/auth/info/implement/KakaoOAuth2UserInfo.java
@@ -1,0 +1,44 @@
+package com.vrr.libs.auth.info.implement;
+
+import com.vrr.libs.auth.info.OAuth2UserInfo;
+
+import java.util.Map;
+
+public class KakaoOAuth2UserInfo extends OAuth2UserInfo {
+
+    public KakaoOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return attributes.get("id").toString();
+    }
+
+    @Override
+    public String getName() {
+        Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
+
+        if (properties == null) {
+            return null;
+        }
+
+        return (String) properties.get("nickname");
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("account_email");
+    }
+
+    @Override
+    public String getImageUrl() {
+        Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
+
+        if (properties == null) {
+            return null;
+        }
+
+        return (String) properties.get("thumbnail_image");
+    }
+}

--- a/application/api/src/main/java/com/vrr/libs/auth/info/implement/NaverOAuth2UserInfo.java
+++ b/application/api/src/main/java/com/vrr/libs/auth/info/implement/NaverOAuth2UserInfo.java
@@ -1,0 +1,56 @@
+package com.vrr.libs.auth.info.implement;
+
+import com.vrr.libs.auth.info.OAuth2UserInfo;
+
+import java.util.Map;
+
+public class NaverOAuth2UserInfo extends OAuth2UserInfo {
+
+    public NaverOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+
+        if (response == null) {
+            return null;
+        }
+
+        return (String) response.get("id");
+    }
+
+    @Override
+    public String getName() {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+
+        if (response == null) {
+            return null;
+        }
+
+        return (String) response.get("nickname");
+    }
+
+    @Override
+    public String getEmail() {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+
+        if (response == null) {
+            return null;
+        }
+
+        return (String) response.get("email");
+    }
+
+    @Override
+    public String getImageUrl() {
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+
+        if (response == null) {
+            return null;
+        }
+
+        return (String) response.get("profile_image");
+    }
+}

--- a/application/api/src/main/java/com/vrr/libs/auth/service/OAuth2UserServiceImpl.java
+++ b/application/api/src/main/java/com/vrr/libs/auth/service/OAuth2UserServiceImpl.java
@@ -56,7 +56,7 @@ public class OAuth2UserServiceImpl extends DefaultOAuth2UserService {
                         "Please use your " + savedUser.getProviderType() + " account to login."
                 );
             }
-            updateUser(savedUser, userInfo);
+            savedUser = updateUser(savedUser, userInfo);
         } else {
             savedUser = createUser(userInfo, providerType);
         }
@@ -78,7 +78,7 @@ public class OAuth2UserServiceImpl extends DefaultOAuth2UserService {
                 now
         );
 
-        return userRepository.saveAndFlush(user);
+        return userRepository.save(user);
     }
 
     private User updateUser(User user, OAuth2UserInfo userInfo) {
@@ -90,6 +90,6 @@ public class OAuth2UserServiceImpl extends DefaultOAuth2UserService {
             user.updateProfile(null, userInfo.getImageUrl());
         }
 
-        return user;
+        return userRepository.save(user);
     }
 }

--- a/application/api/src/main/java/com/vrr/libs/auth/service/OAuth2UserServiceImpl.java
+++ b/application/api/src/main/java/com/vrr/libs/auth/service/OAuth2UserServiceImpl.java
@@ -46,16 +46,17 @@ public class OAuth2UserServiceImpl extends DefaultOAuth2UserService {
 
         OAuth2UserInfo userInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(providerType, user.getAttributes());
         Optional<User> userOptional = userRepository.findBySerialNumber(userInfo.getId());
+
         User savedUser;
         if (userOptional.isPresent()) {
             savedUser = userOptional.get();
             if (providerType != savedUser.getProviderType()) {
                 throw new OAuthProviderMissMatchException(
-                        "Looks like you're signed up with " + providerType +
-                                " account. Please use your " + savedUser.getProviderType() + " account to login."
+                        "Looks like you're signed up with " + providerType + "account. " +
+                        "Please use your " + savedUser.getProviderType() + " account to login."
                 );
             }
-            savedUser = updateUser(savedUser, userInfo);
+            updateUser(savedUser, userInfo);
         } else {
             savedUser = createUser(userInfo, providerType);
         }

--- a/common/src/main/java/com/vrr/code/auth/ProviderType.java
+++ b/common/src/main/java/com/vrr/code/auth/ProviderType.java
@@ -4,7 +4,9 @@ import com.vrr.code.CodeType;
 
 public enum ProviderType implements CodeType {
 
-    GOOGLE("구글", "PVDTP_GOOGLE");
+    GOOGLE("구글", "PVDTP_GOOGLE"),
+    KAKAO("카카오", "PVDTP_KAKAO"),
+    NAVER("네이버", "PVDTP_NAVER");
 
     private final String label;
     private final String code;


### PR DESCRIPTION
## 개요
-  VRR 소셜로그인 선택지를 추가합니다. (NAVER, KAKAO)
- 구글 아이디가 없는 경우 다른 소셜로그인 기능을 통해 로그인하여 가입을 유도할 수 있습니다.

## 작업사항  
-  Naver, Kakao `OAuth2UserInfo` 추가

## 변경로직 (optional)
- Spring Security `OAuth2AuthenticationSuccessHandler` 구조 리펙토링 
  - 기존의 뚱뚱한 `determineTargetUrl` 메소드를 여러 메소드로 분리하여 가독성을 높임
- `OAuth2UserServiceImpl` 사용자 정보 업데이트 로직 수정
  - JPA의 Dirty Checking이 정상적으로 동작하지 않는 문제를 해결함
  - Dirty Checking은 영속성 컨텍스트가 관리하는 도메인 객체의 값이 변경되고, 트랜젝션이 커밋되는 순간 동작함
  - 기존의 update 로직은 도메인 객체의 값이 변경된 뒤 트랜젝션이 커밋되지 않음
  - 따라서 `update`, `create` 로직 모두 트랜젝션을 커밋[`userRespository.save(savedUser)`] 하도록 수정함
