### PR TITLE
docs: 로그인 회원가입 관련 인증 api 문서 추가 [ISSUE-#11]

### DIFF
--- a/application/api/src/docs/asciidoc/index.adoc
+++ b/application/api/src/docs/asciidoc/index.adoc
@@ -23,7 +23,7 @@ VRR 프로젝트 중 인증이 필요한 경우 아래의 API를 활용해 인�
 
 
 === OAuth2 기반 로그인
-* link:./v1/auth/oauth-singin.html[상세 페이지]
+* link:./v1/auth/oauth-signin.html[상세 페이지]
 
 === POST 로그인
 * link:./v1/auth/signin.html[상세 페이지]

--- a/application/api/src/docs/asciidoc/index.adoc
+++ b/application/api/src/docs/asciidoc/index.adoc
@@ -1,0 +1,33 @@
+= VRR API REST DOCS
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+:hardbreaks:
+
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+본 API 문서는 VRR 프로젝트에서 사용중인 API의 상세 정보를 설명하는 문서입니다.
+각 섹션별로 나열된 상세페이지를 통해 각 API 별 End-Point와 요청, 반환 형식을 확인할 수 있습니다.
+
+== 인증
+VRR 프로젝트 중 인증이 필요한 경우 아래의 API를 활용해 인증을 처리할 수 있습니다.
+
+=== 공통 권한 인증 방식
+* 인증이 필요한 API 요청 시에는 공통 권한 인증 방식을 따라 요청해주시기 바랍니다.
+* link:./v1/auth/basic-authorization.html[상세 페이지]
+
+
+=== OAuth2 기반 로그인
+* link:./v1/auth/oauth-singin.html[상세 페이지]
+
+=== POST 로그인
+* link:./v1/auth/signin.html[상세 페이지]
+
+=== POST 회원가입
+* link:./v1/auth/signin.html[상세 페이지]
+

--- a/application/api/src/docs/asciidoc/v1/auth/basic-authorization.adoc
+++ b/application/api/src/docs/asciidoc/v1/auth/basic-authorization.adoc
@@ -1,0 +1,51 @@
+= 공통 권한 인증 방식
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+:hardbreaks:
+
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+== 1. 요청방법
+인증이 필요한 API 요청을 보낼 때에는 Authorization HTTP 헤더를 추가해주시기 바랍니다.
+Authorization 헤더의 값은 다음과 같은 형식을 가져야합니다.
+
+1. 값은 반드시 Bearer로 시작해야 합니다.
+2. Bearer 뒤에는 사전에 발급받은 엑세스 토큰을 가져야 합니다.
+3. Bearer와 엑세스 토큰은 사이에 공백문자 하나를 가져야 합니다.
+
+예시 - Authorization : Bearer {ACCESS_TOKEN}
+
+=== 요청 예시
+[source, http]
+----
+POST /api/1/tour HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer {ACCESS_TOKEN}
+Accept: application/json
+Content-Length: 30
+Host: localhost:8080
+----
+
+== 2. 응답결과
+[cols=2*]
+|===
+|HTTP 상태코드
+|설명
+
+|401 UnAuthorized
+|엑세스 토큰이 잘못되었거나, 비어있는 경우 등등 인증에 실패한 경우 반환하는 상태코드
+
+| NONE
+| 4xx번 대 상태코드를 반환하지 않는다면 인증처리가 정상적으로 처리된 것이다.
+|===
+
+== 3. 주의사항
+HTTP 헤더에 Authorization을 추가할 경우 인증을 받은 사용자임을 명시하는 것으로 간주합니다.
+따라서 인증이 필요없는 API 임에도 HTTP 헤더에 잘못된 Authorization 헤더 값을 넣게 되면 401 에러를 반환합니다.
+

--- a/application/api/src/docs/asciidoc/v1/auth/oauth-signin.adoc
+++ b/application/api/src/docs/asciidoc/v1/auth/oauth-signin.adoc
@@ -1,0 +1,53 @@
+= OAuth2 기반 로그인
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+:hardbreaks:
+
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+== 1. OAuth2 지원 플랫폼
+VRR 서비스는 아래의 플랫폼들에 대해 OAuth2 인증을 지원합니다.
+
+[cols=2*]
+|===
+|플랫폼
+|VRR 인증 End-Point
+
+| Google
+| /oauth2/authorization/google
+
+| Naver
+| /oauth2/authorization/naver
+
+| Kakao
+| /oauth2/authorization/kakao
+|===
+
+
+== 2. OAuth2 로그인 프로세스
+=== 1. Resource Server URL 요청
+* 사용자는 `/oauth2/authorization/{OAUTH_PROVIDER}?redirect_uri="{redirect_url}"에 요청을 보낸다.
+* 서버는 사용자에게 OAuth2 인증을 처리하기 위한 플랫폼 인증 페이지로 리다이렉션한다.
+* 여기서 redirect_uri는 로그인 프로세스가 모두 종료된 후 사용자에게 Access Token을 전달하는 URI 임으로 사용자가 임의로 선정이 가능하다.
+
+=== 2. Resource Server 인증
+* 사용자가 플랫폼 인증 페이지에서 인증한 정보를 토대로 Back-End Server는 Resource Server와 인증을 진행한다.
+* 인증 결과에 따라 인증이 완료되면 #3번 로그인 완료로 이동한다.
+* 만약 인증이 실패했을 경우 에러코드를 redirect_url로 전달한다.
+
+=== 3. 로그인 완료
+* 로그인 완료시에는 사용자가 전달한 redirect_uri로 Back-End Server 인증 토큰과 함께 리다이렉션된다.
+* 이때 예시는 아래와 같다.
+
+[source,http,options="nowrap"]
+----
+REDIECT http://localhost:3000/?token={ACCESS_TOKEN} HTTP/1.1
+SET-COOKIE refresh_token=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI5MjZEOTZDOTAwMzBERDU4NDI5RDI3NTFBQzFCREJCQyIsImV4cCI6MTY1OTI4NDk5OH0.Cr4yvdQ6pvmjx3jsp7AfA0xq1n8jDwgt7m4zVU7fzyw; Path=/; Max-Age=10080000; Expires=Fri, 18 Nov 2022 08:29:58 GMT; HttpOnly
+----
+

--- a/application/api/src/docs/asciidoc/v1/auth/signin.adoc
+++ b/application/api/src/docs/asciidoc/v1/auth/signin.adoc
@@ -1,0 +1,46 @@
+= POST 로그인
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+== REQUEST
+
+=== Request URL
+include::{snippets}/v1-auth-signin/httpie-request.adoc[]
+
+=== Request Headers
+- N/A
+
+=== Request Path Parameters
+- N/A
+
+=== Request Body
+include::{snippets}/v1-auth-signin/request-body.adoc[]
+
+=== Request Fields
+include::{snippets}/v1-auth-signin/request-fields.adoc[]
+
+=== Request HTTP Example
+include::{snippets}/v1-auth-signin/http-request.adoc[]
+
+== RESPONSE
+
+=== Response Headers
+include::{snippets}/v1-auth-signin/response-headers.adoc[]
+
+=== Response Body
+include::{snippets}/v1-auth-signin/response-body.adoc[]
+
+=== Response Fields
+include::{snippets}/v1-auth-signin/response-fields.adoc[]
+
+=== Response HTTP Example
+include::{snippets}/v1-auth-signin/http-response.adoc[]
+

--- a/application/api/src/docs/asciidoc/v1/auth/signup.adoc
+++ b/application/api/src/docs/asciidoc/v1/auth/signup.adoc
@@ -1,0 +1,42 @@
+= POST 회원가입
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+== REQUEST
+
+=== Request URL
+include::{snippets}/v1-auth-signup/httpie-request.adoc[]
+
+=== Request Headers
+- N/A
+
+=== Request Path Parameters
+- N/A
+
+=== Request Body
+include::{snippets}/v1-auth-signup/request-body.adoc[]
+
+=== Request Fields
+include::{snippets}/v1-auth-signup/request-fields.adoc[]
+
+=== Request HTTP Example
+include::{snippets}/v1-auth-signup/http-request.adoc[]
+
+== RESPONSE
+
+=== Response Body
+include::{snippets}/v1-auth-signup/response-body.adoc[]
+
+=== Response HTTP Example
+include::{snippets}/v1-auth-signup/http-response.adoc[]
+
+=== Response Fields
+- N/A

--- a/application/api/src/main/java/com/vrr/application/api/global/config/SecurityConfig.java
+++ b/application/api/src/main/java/com/vrr/application/api/global/config/SecurityConfig.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -26,6 +27,11 @@ public class SecurityConfig {
     private final HttpCookieOAuth2AuthorizationRequestRepository cookieOAuth2AuthorizationRequestRepository;
     private final OAuth2AuthenticationSuccessHandler oauth2AuthenticationSuccessHandler;
     private final OAuth2AuthenticationFailerHandler oAuth2AuthenticationFailerHandler;
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return (web) -> web.ignoring().antMatchers("/document/**");
+    }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {

--- a/application/api/src/test/java/com/vrr/application/api/domain/auth/controller/AuthSignInControllerTest.java
+++ b/application/api/src/test/java/com/vrr/application/api/domain/auth/controller/AuthSignInControllerTest.java
@@ -1,0 +1,94 @@
+package com.vrr.application.api.domain.auth.controller;
+
+import com.epages.restdocs.apispec.ResourceDocumentation;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vrr.application.api.global.libs.ApiDocumentUtils;
+import com.vrr.common.code.auth.ProviderType;
+import com.vrr.common.code.auth.RoleType;
+import com.vrr.domain.entity.auth.User;
+import com.vrr.domain.entity.auth.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.headers.HeaderDocumentation;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.HashMap;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs
+class AuthSignInControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private UserRepository userRepository;
+    @Autowired private PasswordEncoder passwordEncoder;
+
+    @Test
+    void 로그인_정상요청_테스트() throws Exception {
+        // given
+        HashMap<String, String> body = new HashMap<>();
+        body.put("email", "ksy@cmcom.kr");
+        body.put("password", "helloWorld22!!");
+
+        // when
+        User user = userRepository.save(User.builder()
+                .username("sysnar")
+                .email("ksy@cmcom.kr")
+                .serialNumber("ksy@cmcom.kr")
+                .password(passwordEncoder.encode("helloWorld22!!"))
+                .roleType(RoleType.USER)
+                .providerType(ProviderType.VRR)
+                .profileImageUrl("")
+                .emailVerified("Y")
+                .build());
+
+        // then
+        mockMvc.perform(post("/api/1/auth/signin")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(SecurityMockMvcRequestPostProcessors.csrf())
+                        .content(objectMapper.writeValueAsString(body))
+                )
+                .andExpect(status().isCreated())
+                .andDo(document("v1-auth-signin",
+                        ApiDocumentUtils.getDocumentRequest(),
+                        ApiDocumentUtils.getDocumentResponse(),
+                        ResourceDocumentation.resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("인증 API")
+                                        .summary("로그인 API")
+                                        .description("OAuth2 로그인 등이 실패할 경우, 아이디/비밀번호 기반의 로그인을 지원하는 API 입니다.")
+                                        .requestFields(
+                                                fieldWithPath("email").type(JsonFieldType.STRING).description("회원가입 시 입력한 아이디(이메일)"),
+                                                fieldWithPath("password").type(JsonFieldType.STRING).description("아이디(이메일)의 비밀번호")
+                                        )
+                                        .responseHeaders(headerWithName(HttpHeaders.SET_COOKIE).description("Refresh Token"))
+                                        .responseFields(fieldWithPath("accessToken").type(JsonFieldType.STRING).description("로그인 인증 여부를 나타내는 엑세스 토큰"))
+                                        .build()
+                        ),
+                        requestFields(
+                                fieldWithPath("email").type(JsonFieldType.STRING).description("회원가입 시 입력한 아이디(이메일)"),
+                                fieldWithPath("password").type(JsonFieldType.STRING).description("아이디(이메일)의 비밀번호")
+                        ),
+                        responseHeaders(HeaderDocumentation.headerWithName(HttpHeaders.SET_COOKIE).description("Refresh Token")),
+                        responseFields(fieldWithPath("accessToken").type(JsonFieldType.STRING).description("로그인 인증 여부를 나타내는 엑세스 토큰"))
+                ));
+    }
+}

--- a/application/api/src/test/java/com/vrr/application/api/domain/auth/controller/AuthSignUpControllerTest.java
+++ b/application/api/src/test/java/com/vrr/application/api/domain/auth/controller/AuthSignUpControllerTest.java
@@ -1,0 +1,94 @@
+package com.vrr.application.api.domain.auth.controller;
+
+import com.epages.restdocs.apispec.ResourceDocumentation;
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vrr.application.api.domain.auth.dto.AuthSignInRequest;
+import com.vrr.application.api.domain.auth.dto.AuthSignInResponse;
+import com.vrr.application.api.domain.auth.dto.AuthSignUpRequest;
+import com.vrr.application.api.domain.auth.service.AuthResolver;
+import com.vrr.application.api.domain.auth.service.UserCreator;
+import com.vrr.application.api.global.libs.ApiDocumentUtils;
+import com.vrr.domain.entity.auth.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.HashMap;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest
+@AutoConfigureRestDocs
+public class AuthSignUpControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+
+    @MockBean
+    private UserCreator userCreator;
+
+    @MockBean
+    private AuthResolver authResolver;
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void 회원가입_정상요청_테스트() throws Exception {
+        // given
+        HashMap<String, String> body = new HashMap<>();
+        body.put("email", "ksy@cmcom.kr");
+        body.put("password", "helloWorld22!!");
+        body.put("username", "sysnar");
+
+        // when
+        given(userCreator.create(any())).willReturn(new User());
+
+        // then
+        mockMvc.perform(post("/api/1/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(SecurityMockMvcRequestPostProcessors.csrf())
+                        .content(objectMapper.writeValueAsString(body))
+                )
+                .andExpect(status().isCreated())
+                .andDo(document("v1-auth-signUp",
+                        ApiDocumentUtils.getDocumentRequest(),
+                        ApiDocumentUtils.getDocumentResponse(),
+                        ResourceDocumentation.resource(
+                                ResourceSnippetParameters.builder()
+                                        .tag("인증 API")
+                                        .summary("회원가입 API")
+                                        .description("OAuth2 로그인 등이 실패할 경우, 아이디/비밀번호 기반의 회원가입을 지원하는 API 입니다.")
+                                        .requestFields(
+                                                fieldWithPath("email").type(JsonFieldType.STRING).description("회원가입하길 원하는 아이디(이메일)"),
+                                                fieldWithPath("password").type(JsonFieldType.STRING).description("회원가입하길 원하는 비밀번호"),
+                                                fieldWithPath("username").type(JsonFieldType.STRING).description("회원가입하길 원하는 사용자 닉네임")
+                                        )
+                                        .build()
+                        ),
+                        requestFields(
+                                fieldWithPath("email").type(JsonFieldType.STRING).description("회원가입하길 원하는 아이디(이메일)"),
+                                fieldWithPath("password").type(JsonFieldType.STRING).description("회원가입하길 원하는 비밀번호"),
+                                fieldWithPath("username").type(JsonFieldType.STRING).description("회원가입하길 원하는 사용자 닉네임")
+                        )
+                ));
+    }
+}

--- a/application/api/src/test/java/com/vrr/application/api/global/libs/ApiDocumentUtils.java
+++ b/application/api/src/test/java/com/vrr/application/api/global/libs/ApiDocumentUtils.java
@@ -1,0 +1,20 @@
+package com.vrr.application.api.global.libs;
+
+import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
+import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+
+public interface ApiDocumentUtils {
+
+    static OperationRequestPreprocessor getDocumentRequest() {
+        return preprocessRequest(
+                prettyPrint() // 문서의 Request를 이쁘게 출력
+        );
+    }
+
+    static OperationResponsePreprocessor getDocumentResponse() {
+        return preprocessResponse(prettyPrint()); // 문서의 Response 이쁘게 출력
+    }
+}


### PR DESCRIPTION
## 개요
-  VRR 인증 API의 문서를 추가합니다.

## 작업사항  
- OAuth2 로그인 문서를 추가했습니다.
  - Google, Kakao, Naver
- 로그인 API 문서를 추가했습니다.
- 회원가입 API 문서를 추가했습니다.
   
## 변경로직 (optional)
- N/A

## 추후 업데이트 사항 
- 회원가입과 로그인 처리 부분의 예외처리 보완이 이루어져야 합니다.
